### PR TITLE
feat(menu): add quit & Ctrl-C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/
 dist
 build
+.mypy_cache

--- a/aws_ssm_juggle/__init__.py
+++ b/aws_ssm_juggle/__init__.py
@@ -67,17 +67,20 @@ def show_menu(
     indices = dict(zip(source, list(range(0, len(source)))))
     if back:
         items.append(Choice(value=None, name="Back"))
+    items.append(Choice(value="quit", name="Quit"))
     try:
         selection = inquirer.fuzzy(
             message=title,
             long_instruction='Type to search - Press "ESC" to quit',
             choices=items,
-            keybindings={"interrupt": [{"key": "escape"}]},
+            keybindings={"interrupt": [{"key": "escape"}, {"key": "c-c"}]},
         ).execute()
     except KeyboardInterrupt:
         sys.exit(0)
     if selection is None:
         return None, len(source)
+    if selection == "quit":
+        sys.exit(0)
     return selection, indices[selection]
 
 


### PR DESCRIPTION
When first starting the menu I felt stuck as the default Linux-exit method (Ctrl-c) did not work.
Thus I add this shortcut and for non Linux users this PR adds a quit-choice.